### PR TITLE
Release - ShellCheck changes.

### DIFF
--- a/restrictDeployTimes.sh
+++ b/restrictDeployTimes.sh
@@ -7,17 +7,17 @@ echo "Day: $d"
 echo "Hour: $h"
 bypassExpedite="false"
 
-if (($d <= 4)) ; then
+if ((d <= 4)) ; then
     echo "Mon/Tues/Wed/Thurs"
-    if (($h >= 8 && $h < 16)) ; then
+    if ((h >= 8 && h < 16)) ; then
         echo "Work day"
         bypassExpedite="true"
     else
         echo "Out of office hours"
     fi
-elif (($d == 5)) ; then
+elif ((d == 5)) ; then
     echo "Fri"
-    if (($h >= 8 && $h < 14)) ; then
+    if ((h >= 8 && h < 14)) ; then
         echo "Work day"
         bypassExpedite="true"
     else


### PR DESCRIPTION
Tested in TeamCity.

```bash
In ./restrictDeployTimes.sh line 10:
if (($d <= 4)) ; then
     ^-- SC2004: $/${} is unnecessary on arithmetic variables.


In ./restrictDeployTimes.sh line 12:
    if (($h >= 8 && $h < 16)) ; then
         ^-- SC2004: $/${} is unnecessary on arithmetic variables.
                    ^-- SC2004: $/${} is unnecessary on arithmetic variables.


In ./restrictDeployTimes.sh line 18:
elif (($d == 5)) ; then
       ^-- SC2004: $/${} is unnecessary on arithmetic variables.


In ./restrictDeployTimes.sh line 20:
    if (($h >= 8 && $h < 14)) ; then
         ^-- SC2004: $/${} is unnecessary on arithmetic variables.
                    ^-- SC2004: $/${} is unnecessary on arithmetic variables.
```